### PR TITLE
fix: use-cross default false still installing cross

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
 
     - name: Download cross from GitHub releases
       uses: giantswarm/install-binary-action@v1.1.0
-      if: ${{ inputs.use-cross && inputs.cross-version != 'from-source' }}
+      if: ${{ inputs.use-cross == true && inputs.cross-version != 'from-source' }}
       with:
         binary: "cross"
         version: ${{ inputs.cross-version }}
@@ -99,7 +99,7 @@ runs:
 
     - name: Install cross from GitHub latest revision
       shell: bash
-      if: ${{ inputs.use-cross && inputs.cross-version == 'from-source' }}
+      if: ${{ inputs.use-cross == true && inputs.cross-version == 'from-source' }}
       run: |
         cargo install cross --git https://github.com/cross-rs/cross
 


### PR DESCRIPTION
Hi @philss , thanks for great work around rustler precompiled!

I was experiencing an issue were not setting `use-cross` would still run the "install cross" step.

Could it be because of https://github.com/actions/runner/issues/1173?

I had to `use-cross: null` to make it work right in https://github.com/mimiquate/candlex/pull/9/files#diff-bdfe89ee8491e51e3f81ada685c51d24188416d8b529b443ee6085a0e0fd4a4aR45-R47.

Thanks in advance!