### PR TITLE
fix use-cross when false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,7 @@ inputs:
     default: "v0.2.4"
   use-cross:
     description: If the target requires the usage of cross.
+    type: boolean
     required: false
     default: false
   target:


### PR DESCRIPTION
Second attempt at fixing this after #8 getting reverted.

I think it might be happening that `use-cross`  is getting evaluated to `"false"` instead of `false`?

- https://github.com/actions/runner/issues/1483
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callinputsinput_idtype