### PR TITLE
Allowing more apple targets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -146,7 +146,7 @@ runs:
         # See: https://doc.rust-lang.org/reference/linkage.html
         LIB_SUFFIX=".so"
         case ${{ inputs.target }} in
-          *-apple-darwin) LIB_SUFFIX=".dylib" ;;
+          *-apple-*) LIB_SUFFIX=".dylib" ;;
           *-pc-windows-*) LIB_SUFFIX=".dll" ;;
         esac;
 

--- a/action.yml
+++ b/action.yml
@@ -166,7 +166,7 @@ runs:
         # See: https://www.erlang.org/doc/man/erlang.html#load_nif-2
         LIB_FINAL_SUFFIX="${LIB_SUFFIX}"
         case ${{ inputs.target }} in
-          *-apple-darwin) LIB_FINAL_SUFFIX=".so" ;;
+          *-apple-*) LIB_FINAL_SUFFIX=".so" ;;
         esac;
 
         MAYBE_VARIANT_NAME="${{ inputs.variant }}"


### PR DESCRIPTION
We used to support only `*-apple-darwin` targets in the past. But I recently played with precompilation for iOS targets (see [this CI job](https://github.com/tessi/wasmex/actions/runs/16606703984/job/46983003946#step:6:1)).

Turns out, we _almost_ naturally support them, except we need to add all apple targets to be based on the `.dylib` suffix :)